### PR TITLE
creates ephemeral subkeys

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "request": "^2.39.0",
     "ssh-agent": "^0.2.2",
     "ssh-key-to-pem": "^0.11.0",
+    "subkey": "^1.2.1",
     "thunky": "^0.1.0"
   },
   "devDependencies": {},


### PR DESCRIPTION
fixes moose-team/friends#53 via https://github.com/calvinmetcalf/subkey should be backwards compatible api wise but old signatures won't validate with new ones and vice versa
