### PR TITLE
Handle empty response.body when fetching public keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -211,7 +211,7 @@ var create = function (fetchKey) {
 var defaults = create(function (username, cb) {
   request('https://github.com/' + username + '.keys', {timeout: 30000}, function (err, response) {
     if (err) return cb(err)
-    if (response.statusCode !== 200) return cb(new Error('Public keys for ' + username + ' not found'))
+    if (response.statusCode !== 200 || !response.body) return cb(new Error('Public keys for ' + username + ' not found'))
     cb(null, response.body)
   })
 })


### PR DESCRIPTION
This (at least) prevents verify calls from silently failing when the user is keyless
